### PR TITLE
Add leandronsp/agostinho

### DIFF
--- a/participantes/agostinho/README.md
+++ b/participantes/agostinho/README.md
@@ -30,3 +30,12 @@ $ docker compose up -d
 Como o critério de avaliação é um mistério que só será desvendado na live da rinha, compartilho aqui um print clássico de como está a app neste momento (6/Fev/2024) só pra não perder o costume:
 
 <img width="1032" alt="Screenshot 2024-02-06 at 01 07 14" src="https://github.com/leandronsp/rinha-de-backend-2024-q1/assets/385640/7459d89c-6277-4d03-a387-324a8b5766ac">
+
+## Outras participações
+
+O autor também participou da primeira edição da rinha com duas submissões, sendo uma em Ruby e outra em Bash (pelo meme):
+
+* [leandronsp/rinha-backend-ruby](https://github.com/leandronsp/rinha-backend-ruby)
+* [leandronsp/rinha-backend-bash](https://github.com/leandronsp/rinha-backend-bash)
+
+A versão Ruby ficou em 20º lugar (not too bad), ao passo que a versão Bash se deleitou na última posição das submissões que funcionaram, conquistando o tão sonhado 51º lugar (not too bad too).

--- a/participantes/agostinho/README.md
+++ b/participantes/agostinho/README.md
@@ -1,0 +1,26 @@
+# Agostinho (by leandronsp)
+
+[Agostinho](https://github.com/leandronsp/agostinho) é uma modesta versão Ruby (sem Rails) para a **Rinha de Backend 2ª edição, 2024/Q1**. 
+
+## Stack
+
+* 2x Ruby 3.3 [+YJIT](https://shopify.engineering/ruby-yjit-is-production-ready)
+* 1x PostgreSQL
+* 1x NGINX
+
+Esta versão contempla uma stack _handmade_ com Ruby puro, sem Rails nem outro framework mainstream, com o intuito de explorar e testar a utilização de duas bibliotecas construídas pelo autor ainda em fase alpha:
+
+* [leandronsp/adelnor](https://github.com/leandronsp/adelnor) (web server)
+* [leandronsp/chespirito](https://github.com/leandronsp/chespirito) (web framework)
+
+## Autor
+
+👉 **Leandro Proença** - [github/leandronsp](https://github.com/leandronsp)
+👉 [Twitter](https://twitter.com/leandronsp) | [DEV](https://dev.to/leandronsp)
+👉 [leandronsp/agostinho](https://github.com/leandronsp/agostinho)
+
+## Running
+
+```bash
+$ docker compose up -d
+```

--- a/participantes/agostinho/README.md
+++ b/participantes/agostinho/README.md
@@ -1,6 +1,6 @@
-# Agostinho (by leandronsp)
+# agostinho (by leandronsp)
 
-[Agostinho](https://github.com/leandronsp/agostinho) é uma modesta versão Ruby (sem Rails) para a **Rinha de Backend 2ª edição, 2024/Q1**. 
+[agostinho](https://github.com/leandronsp/agostinho) é uma modesta versão Ruby (sem Rails) para esta segunda edição da **famosa e distinta** rinha de backend que visa a utilização de bibliotecas nem um pouco ortodoxas criadas pelo autor _just for fun_.
 
 ## Stack
 
@@ -8,19 +8,25 @@
 * 1x PostgreSQL
 * 1x NGINX
 
-Esta versão contempla uma stack _handmade_ com Ruby puro, sem Rails nem outro framework mainstream, com o intuito de explorar e testar a utilização de duas bibliotecas construídas pelo autor ainda em fase alpha:
+Esta versão contempla uma stack _handmade_ com Ruby puro, sem Rails nem outro framework mainstream, com o intuito de explorar e testar a utilização de duas bibliotecas construídas pelo autor _só porque sim_ ainda em fase alpha:
 
 * [leandronsp/adelnor](https://github.com/leandronsp/adelnor) (web server)
 * [leandronsp/chespirito](https://github.com/leandronsp/chespirito) (web framework)
 
 ## Autor
 
-👉 **Leandro Proença** - [github/leandronsp](https://github.com/leandronsp)
-👉 [Twitter](https://twitter.com/leandronsp) | [DEV](https://dev.to/leandronsp)
-👉 [leandronsp/agostinho](https://github.com/leandronsp/agostinho)
+### Leandro Proença
+
+[Agostinho](https://github.com/leandronsp/agostinho) • [Github](https://github.com/leandronsp) • [Twitter](https://twitter.com/leandronsp) • [DEV](https://dev.to/leandronsp)
 
 ## Running
 
 ```bash
 $ docker compose up -d
 ```
+
+## Confira comigo no replay
+
+Como o critério de avaliação é um mistério que só será desvendado na live da rinha, compartilho aqui um print clássico de como está a app neste momento (6/Fev/2024) só pra não perder o costume:
+
+<img width="1032" alt="Screenshot 2024-02-06 at 01 07 14" src="https://github.com/leandronsp/rinha-de-backend-2024-q1/assets/385640/7459d89c-6277-4d03-a387-324a8b5766ac">

--- a/participantes/agostinho/config/init.sql
+++ b/participantes/agostinho/config/init.sql
@@ -1,0 +1,39 @@
+CREATE TABLE accounts (
+	id SERIAL PRIMARY KEY,
+	name VARCHAR(50) NOT NULL,
+	limit_amount INTEGER NOT NULL
+);
+
+CREATE TABLE transactions (
+	id SERIAL PRIMARY KEY,
+	account_id INTEGER NOT NULL,
+	amount INTEGER NOT NULL,
+	transaction_type CHAR(1) NOT NULL,
+	description VARCHAR(10) NOT NULL,
+	date TIMESTAMP NOT NULL DEFAULT NOW(),
+	CONSTRAINT fk_accounts_transactions_id
+		FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
+CREATE TABLE balances (
+	id SERIAL PRIMARY KEY,
+	account_id INTEGER NOT NULL,
+	amount INTEGER NOT NULL,
+	CONSTRAINT fk_accounts_balances_id
+		FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
+DO $$
+BEGIN
+	INSERT INTO accounts (name, limit_amount)
+	VALUES
+		('o barato sai caro', 1000 * 100),
+		('zan corp ltda', 800 * 100),
+		('les cruders', 10000 * 100),
+		('padaria joia de cocaia', 100000 * 100),
+		('kid mais', 5000 * 100);
+	
+	INSERT INTO balances (account_id, amount)
+		SELECT id, 0 FROM accounts;
+END;
+$$;

--- a/participantes/agostinho/config/nginx.conf
+++ b/participantes/agostinho/config/nginx.conf
@@ -1,0 +1,22 @@
+worker_processes auto;
+
+events {
+	worker_connections 256;
+}
+
+http {
+	access_log off;
+
+	upstream api {
+		server api1:3000;
+		server api2:3000;
+	}
+
+	server {
+		listen 9999;
+
+		location / {
+			proxy_pass http://api;
+		}
+	}
+}

--- a/participantes/agostinho/config/postgresql.conf
+++ b/participantes/agostinho/config/postgresql.conf
@@ -1,0 +1,12 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+
+listen_addresses = '*'
+
+# RESOURCE USAGE
+max_connections = 30
+
+# QUERY TUNING
+random_page_cost = 1.1
+effective_io_concurrency = 30

--- a/participantes/agostinho/docker-compose.yml
+++ b/participantes/agostinho/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  api1: &api
+    image: leandronsp/agostinho
+    container_name: api1
+    environment:
+      - RUBY_YJIT_ENABLE=1
+      - DB_POOL_SIZE=5
+    depends_on:
+      - postgres
+    deploy:
+      resources:
+        limits:
+          cpus: '0.3'
+          memory: '150MB'
+
+  api2: 
+    <<: *api
+    container_name: api2
+
+  postgres:
+    image: postgres
+    container_name: postgres
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - ./config/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./config/postgresql.conf:/etc/postgresql/postgresql.conf
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
+    deploy:
+      resources:
+        limits:
+          cpus: '0.7'
+          memory: '200MB'
+
+  nginx:
+    image: nginx 
+    container_name: nginx
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - 9999:9999
+    depends_on:
+      - api1
+      - api2
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: '50MB'


### PR DESCRIPTION
# Agostinho (by leandronsp)

Adicionando o [agostinho](https://github.com/leandronsp/agostinho) para esta distinta rinha. Agostinho é uma modesta versão Ruby (sem Rails) que visa a utilização de bibliotecas nem um pouco ortodoxas criadas pelo autor _just for fun_.

## Stack

* Ruby 3.3 [+YJIT](https://shopify.engineering/ruby-yjit-is-production-ready)
* PostgreSQL
* NGINX
* [leandronsp/adelnor](https://github.com/leandronsp/adelnor) (web server)
* [leandronsp/chespirito](https://github.com/leandronsp/chespirito) (web framework)

## Print clássico

Compartilhando um print clássico de 6/Fev/24:

<img width="1032" alt="Screenshot 2024-02-06 at 01 07 14" src="https://github.com/zanfranceschi/rinha-de-backend-2024-q1/assets/385640/96bfe439-b13c-455c-8ca6-9b3f08b3037a">
