### PR TITLE
[Importante] [Race Condition] Cobertura de testes para Requisições Paralelas: Cliente Específico

### DIFF
--- a/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
+++ b/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
@@ -179,8 +179,8 @@ class RinhaBackendCrebitosSimulation
             status.saveAs("httpStatus"))
     )
     
-  val debitoParalelo = transacoesParalelas("Requisições de Débito Paralelas", DEBITO)
-  val creditoParalelo = transacoesParalelas("Requisições de Crédito Paralelas", CREDITO)
+  val debitoParalelo = transacoesParalelas("Requisições Paralelas de Débito", DEBITO)
+  val creditoParalelo = transacoesParalelas("Requisições Paralelas de Crédito", CREDITO)
 
   val saldosIniciaisClientes = Array(
     Map("id" -> 1, "limite" ->   1000 * 100),

--- a/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
+++ b/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
@@ -152,7 +152,7 @@ class RinhaBackendCrebitosSimulation
   val validarExtratoAposRequisicoesParalelas = (saldoEsperado: Int, tipo: String) => scenario(s"""Validação do Extrato ${converterTipoParaTexto(tipo)}""")
     .exec(
       http(s"""Validação do Extrato ${converterTipoParaTexto(tipo)}""")
-      .get("/clientes/1/extrato")
+      .get(s"""/clientes/${REQ_PARALELA_ID_CLIENTE}/extrato""")
       .check(
         jmesPath("saldo.total").validate("ConsistenciaSaldoLimite - Extrato", validarSaldoAposRequisicoesParalelas(saldoEsperado)),
         jsonPath("$.ultimas_transacoes[*]").count.is(REQ_PARALELA_NUM_REQUISICOES)

--- a/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
+++ b/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
@@ -25,6 +25,14 @@ class RinhaBackendCrebitosSimulation
     }
   }
 
+  val REQ_PARALELA_ID_CLIENTE = 1
+  val REQ_PARALELA_VALOR_POR_REQUISICAO = 10000
+  val REQ_PARALELA_NUM_REQUISICOES = 10
+  val REQ_PARALELA_SALDO_ESPERADO = (REQ_PARALELA_VALOR_POR_REQUISICAO * REQ_PARALELA_NUM_REQUISICOES)
+
+  val DEBITO = "d"
+  val CREDITO = "c"
+
   val validarConsistenciaSaldoLimite = (valor: Option[String], session: Session) => {
     /*
       Essa função é frágil porque depende que haja uma entrada
@@ -110,6 +118,69 @@ class RinhaBackendCrebitosSimulation
         jmesPath("saldo.total").validate("ConsistenciaSaldoLimite - Extrato", validarConsistenciaSaldoLimite)
     )
   )
+
+  val validarSaldoAposRequisicoesParalelas = (valorFinal: Int) => (saldo: Option[String], session: Session) => {
+    saldo match {
+      case Some(s) if s.toInt == valorFinal => Success(Option("ok"))
+      case _ => Failure("Saldo inconsistente!")
+    }
+  }
+
+  val converterTipoParaTexto = (tipo: String) => if (tipo == "c") "Crédito" else "Débito"
+
+  val resetarSaldo = (valor: Int, tipo: String) => scenario(s"""${converterTipoParaTexto(tipo)} para resetar saldo""")
+    .exec {s =>
+      val descricao = "resetar"
+      val cliente_id = REQ_PARALELA_ID_CLIENTE
+      val payload = s"""{"valor": ${valor}, "tipo": "${tipo}", "descricao": "${descricao}"}"""
+      val session = s.setAll(Map("descricao" -> descricao, "cliente_id" -> cliente_id, "payload" -> payload))
+      session
+    }
+    .exec(
+      http(s"""${converterTipoParaTexto(tipo)} para resetar saldo""")
+      .post(s => s"/clientes/${s("cliente_id").as[String]}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s => s("payload").as[String]))
+          .check(
+            status.in(200, 422),
+            status.saveAs("httpStatus"))
+          .checkIf(s => s("httpStatus").as[String] == "200") { 
+            jmesPath("saldo").ofType[Int].is(0)
+           }
+    )
+
+  val validarExtratoAposRequisicoesParalelas = (saldoEsperado: Int, tipo: String) => scenario(s"""Validação do Extrato ${converterTipoParaTexto(tipo)}""")
+    .exec(
+      http(s"""Validação do Extrato ${converterTipoParaTexto(tipo)}""")
+      .get("/clientes/1/extrato")
+      .check(
+        jmesPath("saldo.total").validate("ConsistenciaSaldoLimite - Extrato", validarSaldoAposRequisicoesParalelas(saldoEsperado)),
+        jsonPath("$.ultimas_transacoes[*]").count.is(REQ_PARALELA_NUM_REQUISICOES)
+      )
+    )
+    .stopInjectorIf(session => "Inconsistência de saldo identificada!", session => session.isFailed)
+
+  val transacoesParalelas = (nome: String, tipo: String) => scenario(nome)
+      .exec {s =>
+      val descricao = randomDescricao()
+      val cliente_id = REQ_PARALELA_ID_CLIENTE
+      val valor = REQ_PARALELA_VALOR_POR_REQUISICAO
+      val payload = s"""{"valor": ${valor}, "tipo": "${tipo}", "descricao": "${descricao}"}"""
+      val session = s.setAll(Map("descricao" -> descricao, "cliente_id" -> cliente_id, "payload" -> payload))
+      session
+    }
+    .exec(
+      http(nome)
+      .post(s => s"/clientes/${s("cliente_id").as[String]}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s => s("payload").as[String]))
+          .check(
+            status.in(200, 422),
+            status.saveAs("httpStatus"))
+    )
+    
+  val debitoParalelo = transacoesParalelas("Requisições de Débito Paralelas", DEBITO)
+  val creditoParalelo = transacoesParalelas("Requisições de Crédito Paralelas", CREDITO)
 
   val saldosIniciaisClientes = Array(
     Map("id" -> 1, "limite" ->   1000 * 100),
@@ -220,18 +291,44 @@ class RinhaBackendCrebitosSimulation
     criteriosClientes.inject(
       atOnceUsers(1)
     ).andThen(
-      debitos.inject(
-        rampUsersPerSec(1).to(220).during(2.minutes),
-        constantUsersPerSec(220).during(2.minutes)
-      ),
-      creditos.inject(
-        rampUsersPerSec(1).to(110).during(2.minutes),
-        constantUsersPerSec(110).during(2.minutes)
-      ),
-      extratos.inject(
-        rampUsersPerSec(1).to(10).during(2.minutes),
-        constantUsersPerSec(10).during(2.minutes)
+      debitoParalelo.inject(
+        atOnceUsers(10)
       )
+      .andThen(
+        validarExtratoAposRequisicoesParalelas(REQ_PARALELA_SALDO_ESPERADO * -1, DEBITO).inject(
+          atOnceUsers(1)
+        )
+        .andThen(
+          resetarSaldo(REQ_PARALELA_SALDO_ESPERADO, CREDITO).inject(
+            atOnceUsers(1)
+          )
+        )
+      ).andThen(
+        creditoParalelo.inject(
+          atOnceUsers(10)
+        ).andThen(
+          validarExtratoAposRequisicoesParalelas(REQ_PARALELA_SALDO_ESPERADO, CREDITO).inject(
+            atOnceUsers(1)
+          ).andThen(
+            resetarSaldo(REQ_PARALELA_SALDO_ESPERADO, DEBITO).inject(
+              atOnceUsers(1)
+            )
+          )
+        )
+      ).andThen(
+        debitos.inject(
+          rampUsersPerSec(1).to(220).during(2.minutes),
+          constantUsersPerSec(220).during(2.minutes)
+        ),
+        creditos.inject(
+          rampUsersPerSec(1).to(110).during(2.minutes),
+          constantUsersPerSec(110).during(2.minutes)
+        ),
+        extratos.inject(
+          rampUsersPerSec(1).to(10).during(2.minutes),
+          constantUsersPerSec(10).during(2.minutes)
+        )
+      ),
     )
   ).protocols(httpProtocol)
 }


### PR DESCRIPTION
Fala, pessoal. Estou abrindo esse PR para resolver o problema da issue https://github.com/zanfranceschi/rinha-de-backend-2024-q1/issues/142 

Com essa modificação, após as validações iniciais, vamos sair com 10 requisições paralelas para debitar/creditar o mesmo cliente e posteriormente validar o extrato para garantir que o saldo está batendo com o esperado. Assim, vamos garantir que esse problema de Race Condition reportado na issue seja identificado e travado durante o teste.

Além desse ponto, também coloquei para finalizar a execução do teste caso exista uma inconsistência nessa etapa, para evitar que isso gere side-effects na execução dos outros testes.

Quando rodamos o teste na API problemática (a mesma que usei para reportar na issue) já recebemos o erro de imediato, como vocês podem ver no screenshot abaixo:

![image](https://github.com/zanfranceschi/rinha-de-backend-2024-q1/assets/28747696/9e196ec8-41f7-414d-9614-863b99a56cb5)

Quando rodamos o novo teste de carga em uma API funcional, o teste segue o fluxo corretamente:

![image](https://github.com/zanfranceschi/rinha-de-backend-2024-q1/assets/28747696/1e83fb40-0db2-4328-ad09-92fd4f284041)

![image](https://github.com/zanfranceschi/rinha-de-backend-2024-q1/assets/28747696/9fff8230-115f-4775-919c-c7877932182c)

Qualquer coisa só falar =)


***Eu não codo em scala, então se tiverem pontos para melhorar, por favor, solicite no code review.***