### PR TITLE
change memory do api

### DIFF
--- a/participantes/newton/docker-compose.yml
+++ b/participantes/newton/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       resources:
         limits:
           cpus: "0.3"
-          memory: "175MB"
+          memory: "200MB"
 
   api02:
     <<: *api 
@@ -44,7 +44,7 @@ services:
       resources:
         limits:
           cpus: "0.1"
-          memory: "50MB"
+          memory: "20MB"
 
   db:
     image: postgres:14.1-alpine
@@ -63,7 +63,7 @@ services:
       resources:
         limits:
           cpus: "0.8"
-          memory: "150MB"
+          memory: "130MB"
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d rinha_backend" ]
       interval: 3s

--- a/participantes/newton/testada
+++ b/participantes/newton/testada
@@ -1,2 +1,0 @@
-testada em Fri Feb 16 13:04:55 UTC 2024
-abra um PR removendo esse arquivo caso queira que sua API seja testada novamente


### PR DESCRIPTION
De acordo com os logs o container crashou com status 137  (The operating system's out of memory manager ) algo nesse sentido tenho dúvidas se tem a ver com a máquina ou com o container em si uma vez que localmente o docker-compose executou sem problemas o teste. De qualquer forma, tentando outra config. 