### PR TITLE
Melhora portabilidade do script de execução dos benchmarks

### DIFF
--- a/executar-teste-local.sh
+++ b/executar-teste-local.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Use este script para executar testes locais
 


### PR DESCRIPTION
A shebang `!#/usr/bin/bash` não é válida em todos sistemas, eu por exemplo uso NixOS e tive que alterar ela pra conseguir rodar o script localmente

O ideal é usar o programa `env` pra pegar o caminho pro bash disponível no sistema

Discussão relevante: https://stackoverflow.com/a/10383546