### PR TITLE
lucasew-tigerbeetle: seccomp tá embaçando com o backend também, unconfinando

### DIFF
--- a/participantes/lucasew-go-tigerbeetle/docker-compose.yaml
+++ b/participantes/lucasew-go-tigerbeetle/docker-compose.yaml
@@ -52,6 +52,8 @@ services:
         limits:
           cpus: "0.3"
           memory: "50MB"
+    security_opt:
+      - seccomp:unconfined
     # build:
     #   dockerfile: ./Dockerfile.go-backend
     depends_on:
@@ -71,6 +73,8 @@ services:
         limits:
           cpus: "0.3"
           memory: "50MB"
+    security_opt:
+      - seccomp:unconfined
     # build:
     #   dockerfile: ./Dockerfile.go-backend
     depends_on:


### PR DESCRIPTION


**Por favor, marque com um `x` os requisitos que antendeu antes de prosseguir com o pull request.**

- [x] Incluí um README.md com informações sobre minha participação.
- [x] Não ultrapassei os limites de memória (550MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.
