### PR TITLE
Ajusta a bagaça e envia dinovo para teste

### DIFF
--- a/participantes/isaquealves/docker-compose.yml
+++ b/participantes/isaquealves/docker-compose.yml
@@ -1,12 +1,7 @@
 version: "3.8"
 
-x-build: &default-build
-  context: .
-  dockerfile: Dockerfile
-
 services:
   host1: &api
-    build: *default-build
     image: isaquealves/zebrito:latest
     hostname: host1
     environment:
@@ -24,7 +19,6 @@ services:
 
   host2:
     <<: *api
-    build: *default-build
     hostname: host2
     environment:
       - DB_HOSTNAME=db

--- a/participantes/isaquealves/testada
+++ b/participantes/isaquealves/testada
@@ -1,2 +1,0 @@
-testada em Sat Feb 24 19:47:51 UTC 2024
-abra um PR removendo esse arquivo caso queira que sua API seja testada novamente


### PR DESCRIPTION
Removi a referencia ao Dockerfile que estava causando quebra. Não tava conseguindo replicar por vacilo. Pra 'ver' o problema precisei rodar um `docker system prune --all `. Bastava ter lido com atenção o docker-compose.yml de novo #ficaadica.

**Por favor, marque com um `x` os requisitos que antendeu antes de prosseguir com o pull request.**

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Não ultrapassei os limites de memória (550MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.
