### PR TITLE
lucasew-go-tigerbeetle: de novo

### DIFF
--- a/participantes/lucasew-go-tigerbeetle/docker-compose.yaml
+++ b/participantes/lucasew-go-tigerbeetle/docker-compose.yaml
@@ -44,8 +44,7 @@ services:
     environment:
       - "TB_ADDRESS=db:3000"
       - "TIGERBEETLE_MAX_CONCURRENCY=320"
-      - "GOMEMLIMIT=45MiB"
-      - "GOGC=1000"
+      - GOGC=off
 
     deploy:
       resources:
@@ -65,8 +64,7 @@ services:
     environment:
       - "TB_ADDRESS=db:3000"
       - "TIGERBEETLE_MAX_CONCURRENCY=320"
-      - "GOMEMLIMIT=45MiB"
-      - "GOGC=1000"
+      - GOGC=off
 
     deploy:
       resources:

--- a/participantes/lucasew-go-tigerbeetle/testada
+++ b/participantes/lucasew-go-tigerbeetle/testada
@@ -1,2 +1,0 @@
-testada em Fri Feb 23 19:55:32 UTC 2024
-abra um PR removendo esse arquivo caso queira que sua API seja testada novamente


### PR DESCRIPTION
Parece que o ciclo de gc ta causando problema, como to usando uma versao adaptada do tb pra usar menos ram deixa o go rodar sem gc, quando passar do limite o docker mata e o compose reinicia a API, como tem redundancia só dale

**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Não ultrapassei os limites de memória (550MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.
