### PR TITLE
Gitignore: Adicionando linha para ignorar arquivo de navegação do MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ RESULTADOS-HEADER.md
 sync-git.sh
 
 quantos-testes-faltam?.sh
+
+*.DS_Store


### PR DESCRIPTION
Este PR visa apenas adicionar uma regra para ignorar o arquivo de navegação que o MacOS gera em todas as pastas que são abertas pelo Finder. O nome do arquivo é .DS_Store