### PR TITLE
Removendo teste e arrumando o docker compose 

### DIFF
--- a/participantes/diogoviana/docker-compose.yml
+++ b/participantes/diogoviana/docker-compose.yml
@@ -1,19 +1,15 @@
 version: "3.5"
 
 services:
-  api01:
-    #build: .
-    &api
+  api01: &api
     image: diogoviana/rinhadebackend
     volumes:
-      - .:/app
       - shared-volume:/app/storage
       - sockets:/app/tmp
     hostname: api01
     ports:
       - "3001:3000"
     environment:
-      #- RACK_ENV=production
       - RACK_ENV=development
       - RACK_MAX_THREADS=3
       - WEB_CONCURRENCY=0

--- a/participantes/diogoviana/testada
+++ b/participantes/diogoviana/testada
@@ -1,2 +1,0 @@
-testada em Wed Feb 28 03:32:11 UTC 2024
-abra um PR removendo esse arquivo caso queira que sua API seja testada novamente


### PR DESCRIPTION
Esqueci um volume de dev no docker compose, que fez o teste não rodar pq não achava o arquivo de entrypoint. 

**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Não ultrapassei os limites de memória (550MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.

