### PR TITLE
Fix docker compose volume declaration

### DIFF
--- a/participantes/mdamaceno-ruby/docker-compose.yml
+++ b/participantes/mdamaceno-ruby/docker-compose.yml
@@ -32,7 +32,9 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: rinha2024
     volumes:
-      - ./docker/db/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - type: bind
+        source: ./docker/db/init.sql
+        target: /docker-entrypoint-initdb.d/init.sql
     ports:
       - 5432:5432
     networks:
@@ -53,7 +55,10 @@ services:
     ports:
       - 9999:9999
     volumes:
-      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - type: bind
+        source: ./docker/nginx/nginx.conf
+        target: /etc/nginx/nginx.conf
+        read_only: true
     networks:
       - rinha-network
     depends_on:

--- a/participantes/mdamaceno-ruby/testada
+++ b/participantes/mdamaceno-ruby/testada
@@ -1,2 +1,0 @@
-testada em Sun Mar 10 04:21:01 UTC 2024
-abra um PR removendo esse arquivo caso queira que sua API seja testada novamente


### PR DESCRIPTION
Este PR tem o objetivo de especificar melhor o tipo de volume no docker-compose já que no log apareceu o seguinte erro:

![image](https://github.com/zanfranceschi/rinha-de-backend-2024-q1/assets/4340542/a15ff2e5-0df3-434d-b184-be212d61d874)


**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Não ultrapassei os limites de memória (550MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.

